### PR TITLE
fix arg passed error in func get_correspondence

### DIFF
--- a/src/models/pano/utils.py
+++ b/src/models/pano/utils.py
@@ -27,7 +27,7 @@ def get_correspondences(R, K, img_h, img_w):
                     R_left@torch.inverse(K_left))
             
 
-            xyz_l = torch.tensor(get_x_2d(img_h, img_w),
+            xyz_l = torch.tensor(get_x_2d(img_w, img_h),
                                 device=R.device)
             xyz_l = (
                 xyz_l.reshape(-1, 3).T)[None].repeat(homo_l.shape[0], 1, 1)


### PR DESCRIPTION
Hi, Tang. I found another bug which is similar to #24: the args passed get_x_2d ought to be (w, h). Unlike #24, it didn't raise an explicit error when height: width of inputs is not 1:1,  this part of code just returns wrong correspondence in that case, which made my training failed.

Thank you.
