### PR TITLE
Read stable diffusion format prompts from PNGs

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -6,8 +6,12 @@ from src.lightning_pano_outpaint import PanoOutpaintGenerator
 import numpy as np
 import cv2
 import os
+os.environ['KMP_DUPLICATE_LIB_OK']='True'
 from generate_video_tool.pano_video_generation import generate_video
 from PIL import Image
+from exiftool import ExifToolHelper
+from datetime import datetime
+
 torch.manual_seed(0)
 
 def get_K_R(FOV, THETA, PHI, height, width):
@@ -65,8 +69,9 @@ if args.image_path is None:
     config_file = 'configs/pano_generation.yaml'
     config = yaml.load(open(config_file, 'rb'), Loader=yaml.SafeLoader)
     model = PanoGenerator(config)
-    model.load_state_dict(torch.load('weights/pano.ckpt', map_location='cpu')[
-            'state_dict'], strict=True)
+    model.load_state_dict(torch.load('weights/pano.ckpt', map_location='cpu')['state_dict'], strict=True)
+    #saved_ckpt = torch.load('weights/pano.ckpt', map_location='cpu')
+    #model.load_state_dict(saved_ckpt, strict=False)
     model=model.cuda()
     img=None
 else:
@@ -74,16 +79,30 @@ else:
     config_file = 'configs/pano_generation_outpaint.yaml'
     config = yaml.load(open(config_file, 'rb'), Loader=yaml.SafeLoader)
     model = PanoOutpaintGenerator(config)
-    model.load_state_dict(torch.load('weights/pano_outpaint.ckpt', map_location='cpu')[
-            'state_dict'], strict=True)
+    model.load_state_dict(torch.load('weights/pano_outpaint.ckpt', map_location='cpu')['state_dict'], strict=True)
+    #saved_ckpt = torch.load('weights/pano_outpaint.ckpt', map_location='cpu')
+    #model.load_state_dict(saved_ckpt, strict=False)
     model=model.cuda()
 
     img=cv2.imread(args.image_path)
     img=cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     img=resize_and_center_crop(img, config['dataset']['resolution'])
-    img=img/127.5-1
-
+    img=img/127.5-1       
     img=torch.tensor(img).cuda()
+    
+    #read stable diffusion prompts from PNG
+    with ExifToolHelper() as et:
+        #print EXIF metadata
+        EXIF_dict = et.get_metadata(args.image_path)
+        print(f'Metadata: {EXIF_dict}')        
+        if 'PNG:Parameters' in EXIF_dict[0]:
+            PNGparameters = EXIF_dict[0]['PNG:Parameters']
+            parsed_parameters = PNGparameters.split("\n")        
+            positive_prompt = parsed_parameters[0]
+            negative_prompt = parsed_parameters[1]
+            print(f'Positive promts: ' +  positive_prompt)
+            print(f'Negative promts: ' +  negative_prompt)
+            args.text= positive_prompt
     
 resolution=config['dataset']['resolution']
 Rs=[]
@@ -107,7 +126,7 @@ if args.text_path is not None:
         for i, line in enumerate(f):
             prompt.append(line.strip())
     if len(prompt)<8:
-        raise ValueError('text file should contain 8 lines')
+        raise ValueError('text file should contain 8 lines for each camera view')
     args.text=prompt[0]
 else:
     prompt=[args.text]*8
@@ -121,11 +140,12 @@ batch= {
         'K': K
     }
 images_pred=model.inference(batch)
-res_dir=args.text[:20]
-print('save in fold: {}'.format(res_dir))
+#res_dir=os.path.join('outputs/',args.text[:20])
+res_dir=os.path.join('outputs/',f'results'+datetime.now().strftime('--%Y%m%d-%H%M%S'))
+print('saved to the folder: {}'.format(res_dir))
 os.makedirs(res_dir, exist_ok=True)
 with open(os.path.join(res_dir, 'prompt.txt'), 'w') as f:
-    f.write(args.text)
+    f.write(args.text)    
 image_paths=[]
 for i in range(8):
     im = Image.fromarray(images_pred[0,i])


### PR DESCRIPTION
Thought it would be convenient when generating panoramas with images made by stable diffusion.
Added prompt lookup when referencing PNG with embedded stable diffusion prompts. 

Prerequisites>
1. EXIFtool is needed for EXIF parsing. Acquire the latest version from their [official homepage](https://exiftool.org/). Also Path enviroment variable should be added for the EXIFtool to be accessible via command prompt shell/terminal
2. Pyexiftool package is required as a wrapper. Install via `pip install pyexiftool`. 
3. modified output path. results are saved under './outputs/result--YYMMDD-TIME' directory